### PR TITLE
handle receiving empty/null props in SocketIoChannel listener

### DIFF
--- a/lib/src/channel/socketio-channel.dart
+++ b/lib/src/channel/socketio-channel.dart
@@ -84,10 +84,12 @@ class SocketIoChannel extends Channel {
 
     if (this.events[event] == null) {
       this.events[event] = (props) {
-        String channel = props[0];
-        dynamic data = props[1];
-        if (this.name == channel && this._listeners[event]!.isNotEmpty) {
-          this._listeners[event]!.forEach((cb) => cb(data));
+        if(props is List&&props.length>1){
+          String channel = props[0];
+          dynamic data = props[1];
+          if (this.name == channel && this._listeners[event]!.isNotEmpty) {
+            this._listeners[event]!.forEach((cb) => cb(data));
+          }
         }
       };
 


### PR DESCRIPTION
I received this error while auto reconnect after disconnecting on Socket IO 


```
 Unhandled Exception: NoSuchMethodError: The method '[]' was called on null.
Receiver: null
Tried calling: [](0)
#0      Object.noSuchMethod (dart:core-patch/object_patch.dart:38:5)
#1      SocketIoChannel.on.<anonymous closure> (package:laravel_echo/src/channel/socketio-channel.dart:90:31)
#2      EventEmitter.emit.<anonymous closure> (package:socket_io_common/src/util/event_emitter.dart:51:14)
#3      List.forEach (dart:core-patch/growable_array.dart:416:8)
#4      EventEmitter.emit (package:socket_io_common/src/util/event_emitter.dart:50:11)
#5      Socket.emitWithAck (package:socket_io_client/src/socket.dart:138:13)
#6      Socket.emit (package:socket_io_client/src/socket.dart:123:5)
#7      Socket.onconnect (package:socket_io_client/src/socket.dart:326:5)
#8      Socket.onpacket (package:socket_io_client/src/socket.dart:222:9)
#9      EventEmitter.emit.<anonymous closure> (package:socket_io_common/src/util/event_emitter.dart:51:14)
#10     List.forEach (dart:core-patch/growable_array.dart:416:8)
#11     EventEmitter.emit (package:socket_io_common/src/util/event_emitter.dart:50:11)
#12     Manager.ondecoded (package:socket_io_client/src/manager.dart:283:5)
#13     EventEmitter.emit.<anonymous closure> (package:socket_io_common/src/util/event_emitter.dart:51:14)
#14     List.forEach (dart:core-patch/growable_array.dart:416:8)
#15     EventEmitter.emit (package:socket_io_common/src/util/event_emitter.dart:50:11)
#16     Decoder.add (package:socket_io_common/src/parser/parser.dart:159:14)
#17     Manager.ondata (package:socket_io_client/src/manager.dart:274:13)
#18     EventEmitter.emit.<anonymous closure> (package:socket_io_common/src/util/event_emitter.dart:51:14)
#19     List.forEach (dart:core-patch/growable_array.dart:416:8)
#20     EventEmitter.emit (package:socket_io_common/src/util/event_emitter.dart:50:11)
#21     Socket.onPacket (package:socket_io_client/src/engine/socket.dart:462:11)
#22     Socket.setTransport.<anonymous closure> (package:socket_io_client/src/engine/socket.dart:287:34)
#23     EventEmitter.emit.<anonymous closure> (package:socket_io_common/src/util/event_emitter.dart:51:14)
#24     List.forEach (dart:core-patch/growable_array.dart:416:8)
#25     EventEmitter.emit (package:socket_io_common/src/util/event_emitter.dart:50:11)
#26     Transport.onPacket (package:socket_io_client/src/engine/transport/transport.dart:128:5)
#27     Transport.onData (package:socket_io_client/src/engine/transport/transport.dart:122:5)
#28     IOWebSocketTransport.addEventListeners.<anonymous closure> (package:socket_io_client/src/engine/transport/io_websocket_transport.dart:67:7)
#29     _RootZone.runUnaryGuarded (dart:async/zone.dart:1586:10)
#30     _BufferingStreamSubscription._sendData (dart:async/stream_impl.dart:339:11)
#31     _BufferingStreamSubscription._add (dart:async/stream_impl.dart:271:7)
#32     _SyncStreamControllerDispatch._sendData (dart:async/stream_controller.dart:774:19)
#33     _StreamController._add (dart:async/stream_controller.dart:648:7)
#34     _StreamController.add (dart:async/stream_controller.dart:596:5)
#35     new _WebSocketImpl._fromSocket.<anonymous closure> (dart:_http/websocket_impl.dart:1144:21)
#36     _RootZone.runUnaryGuarded (dart:async/zone.dart:1586:10)
#37     _BufferingStreamSubscription._sendData (dart:async/stream_impl.dart:339:11)
#38     _BufferingStreamSubscription._add (dart:async/stream_impl.dart:271:7)
#39     _SinkTransformerStreamSubscription._add (dart:async/stream_transformers.dart:63:11)
#40     _EventSinkWrapper.add (dart:async/stream_transformers.dart:13:11)
#41     _WebSocketProtocolTransformer._messageFrameEnd (dart:_http/websocket_impl.dart:332:23)
#42     _WebSocketProtocolTransformer.add (dart:_http/websocket_impl.dart:226:46)
#43     _SinkTransformerStreamSubscription._handleData (dart:async/stream_transformers.dart:111:24)
#44     _HttpDetachedStreamSubscription._maybeScheduleData.<anonymous closure> (dart:_http/http_parser.dart:173:20)
#45     _microtaskLoop (dart:async/schedule_microtask.dart:40:21)
#46     _startMicrotaskLoop (dart:async/schedule_microtask.dart:49:5)

```

I fixed it by simply checking props before calling the listener.

Before:
`
(props) {
        String channel = props[0];
        dynamic data = props[1];
        if (this.name == channel && this._listeners[event]!.isNotEmpty) {
          this._listeners[event]!.forEach((cb) => cb(data));
        }
      }
`

After:
`
(props) {
        if(props is List&&props.length>1){
          String channel = props[0];
          dynamic data = props[1];
          if (this.name == channel && this._listeners[event]!.isNotEmpty) {
            this._listeners[event]!.forEach((cb) => cb(data));
          }
        }
      }
`